### PR TITLE
Support for all unix systems

### DIFF
--- a/src/connection/ipc/IpcDriver.ts
+++ b/src/connection/ipc/IpcDriver.ts
@@ -17,15 +17,16 @@ export default class IpcDriver {
     }
 
     public static getIpcPath(id = 0) {
-        switch (process.platform) {
-            case 'linux':
-                return `${process.env.XDG_RUNTIME_DIR}/discord-ipc-${id}`;
-            case 'win32':
-                return `\\\\?\\pipe\\discord-ipc-${id}`;
-            case 'darwin':
-                return `${process.env.TMPDIR}/discord-ipc-${id}`;
-            default:
-                throw new Error(`Platform '${process.platform}' is not supported at the moment`);
+        if (process.platform === 'win32') {
+            return `\\\\?\\pipe\\discord-ipc-${id}`;
         }
+
+        const temp_dir = process.env.XDG_RUNTIME_DIR 
+                            || process.env.TMP 
+                            || process.env.TEMP 
+                            || process.env.TMPDIR
+                            || "/tmp";
+
+        return `${temp_dir}/discord-ipc-${id}`;
     }
 }

--- a/src/connection/ipc/IpcDriver.ts
+++ b/src/connection/ipc/IpcDriver.ts
@@ -22,9 +22,9 @@ export default class IpcDriver {
         }
 
         const temp_dir = process.env.XDG_RUNTIME_DIR 
+                            || process.env.TMPDIR
                             || process.env.TMP 
                             || process.env.TEMP 
-                            || process.env.TMPDIR
                             || "/tmp";
 
         return `${temp_dir}/discord-ipc-${id}`;

--- a/src/connection/ipc/IpcDriver.ts
+++ b/src/connection/ipc/IpcDriver.ts
@@ -21,12 +21,12 @@ export default class IpcDriver {
             return `\\\\?\\pipe\\discord-ipc-${id}`;
         }
 
-        const temp_dir = process.env.XDG_RUNTIME_DIR 
-                            || process.env.TMPDIR
-                            || process.env.TMP 
-                            || process.env.TEMP 
-                            || "/tmp";
+        const tmpDir = process.env.XDG_RUNTIME_DIR
+            || process.env.TMPDIR
+            || process.env.TMP
+            || process.env.TEMP
+            || '/tmp';
 
-        return `${temp_dir}/discord-ipc-${id}`;
+        return `${tmpDir}/discord-ipc-${id}`;
     }
 }


### PR DESCRIPTION
По факту, от всех путей отличается только спец. путь для Windows, все остальные системы - Unix подобные, каждый дистрибутив сам может задать свою переменную в env.

Для более красивого кода можно было создать константу:
```ts
const unix_paths = ["XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP"];

for (const path of unix_paths ) {
     process.env[path] // И тут уже ковырять
}
```

Но это как по мне довольно медленно по отношению к заранее известными переменным.